### PR TITLE
Build ARM64 Linux container image via buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,19 +51,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Build and push image
         run: |
           VERSION=${GITHUB_REF_NAME#v}
-          docker build \
+          docker buildx build \
+            --platform linux/arm64 \
             -t ghcr.io/argylebits/roadrunner:latest \
             -t ghcr.io/argylebits/roadrunner:${VERSION} \
             -f images/Containerfile \
+            --push \
             images/
-          docker push ghcr.io/argylebits/roadrunner:latest
-          docker push ghcr.io/argylebits/roadrunner:${VERSION}
 
   release:
     name: Create release & update Homebrew

--- a/docs/workflow-templates/release.yml
+++ b/docs/workflow-templates/release.yml
@@ -51,19 +51,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Build and push image
         run: |
           VERSION=${GITHUB_REF_NAME#v}
-          docker build \
+          docker buildx build \
+            --platform linux/arm64 \
             -t ghcr.io/argylebits/roadrunner:latest \
             -t ghcr.io/argylebits/roadrunner:${VERSION} \
             -f images/Containerfile \
+            --push \
             images/
-          docker push ghcr.io/argylebits/roadrunner:latest
-          docker push ghcr.io/argylebits/roadrunner:${VERSION}
 
   release:
     name: Create release & update Homebrew


### PR DESCRIPTION
## Summary
- Use Docker Buildx + QEMU to cross-compile the container image for `linux/arm64`
- The previous build produced an x86_64-only image which Apple's `container` CLI on ARM Macs can't run

## Test plan
- [ ] Release workflow builds and pushes ARM64 image
- [ ] `roadrunner run` pulls and boots the image on Apple Silicon