### PR TITLE
Remove unused vz.entitlements

### DIFF
--- a/signing/vz.entitlements
+++ b/signing/vz.entitlements
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.virtualization</key>
-    <true/>
-</dict>
-</plist>


### PR DESCRIPTION
## Summary
- Remove `signing/vz.entitlements` — only needed for the programmatic Containerization API (Approach A), not the current subprocess approach

## Test plan
- [x] `swift build` and `swift test` still pass (entitlements not referenced anywhere)