### PR TITLE
Separate container image build from release workflow

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,40 @@
+name: Container Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/**'
+
+permissions:
+  packages: write
+
+jobs:
+  build-image:
+    name: Build container image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Get version
+        id: version
+        run: echo "version=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 'latest')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            -t ghcr.io/argylebits/roadrunner:latest \
+            -t ghcr.io/argylebits/roadrunner:${{ steps.version.outputs.version }} \
+            -f images/Containerfile \
+            --push \
+            images/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   build-binary:
@@ -45,35 +44,9 @@ jobs:
             roadrunner-macos-arm64.tar.gz
             roadrunner-*-installer.pkg
 
-  build-image:
-    name: Build container image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Build and push image
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          docker buildx build \
-            --platform linux/arm64 \
-            -t ghcr.io/argylebits/roadrunner:latest \
-            -t ghcr.io/argylebits/roadrunner:${VERSION} \
-            -f images/Containerfile \
-            --push \
-            images/
-
   release:
     name: Create release & update Homebrew
-    needs: [build-binary, build-image]
+    needs: [build-binary]
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4

--- a/docs/workflow-templates/release.yml
+++ b/docs/workflow-templates/release.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   build-binary:
@@ -45,35 +44,9 @@ jobs:
             roadrunner-macos-arm64.tar.gz
             roadrunner-*-installer.pkg
 
-  build-image:
-    name: Build container image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Build and push image
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          docker buildx build \
-            --platform linux/arm64 \
-            -t ghcr.io/argylebits/roadrunner:latest \
-            -t ghcr.io/argylebits/roadrunner:${VERSION} \
-            -f images/Containerfile \
-            --push \
-            images/
-
   release:
     name: Create release & update Homebrew
-    needs: [build-binary, build-image]
+    needs: [build-binary]
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Move container image build into its own workflow (`image.yml`) that only triggers when `images/` changes on main
- Remove image build from the release workflow so tagged releases don't unnecessarily rebuild the same image
- Release workflow no longer needs `packages: write` permission

## Test plan
- [ ] Tag a release and verify only binary build + Homebrew update runs (no image build)
- [ ] Push a change to `images/` on main and verify the image workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)