### PR TITLE
Auto-fix container system and kernel in preflight checks

### DIFF
--- a/Sources/Roadrunner/Preflight.swift
+++ b/Sources/Roadrunner/Preflight.swift
@@ -3,7 +3,8 @@ import Foundation
 enum Preflight {
     static func check() throws {
         try checkContainerCLI()
-        try checkContainerSystem()
+        try ensureContainerSystem()
+        try ensureKernelConfigured()
     }
 
     private static func checkContainerCLI() throws {
@@ -13,7 +14,38 @@ enum Preflight {
         }
     }
 
-    private static func checkContainerSystem() throws {
+    private static func ensureContainerSystem() throws {
+        if isContainerSystemRunning() { return }
+
+        print("[roadrunner] Container system is not running, starting it...")
+        let start = Process()
+        start.executableURL = URL(filePath: ContainerRunner.containerCLI)
+        start.arguments = ["system", "start"]
+        start.standardOutput = FileHandle.standardOutput
+        start.standardError = FileHandle.standardError
+
+        do {
+            try start.run()
+            start.waitUntilExit()
+        } catch {
+            throw PreflightError.containerSystemStartFailed
+        }
+
+        guard start.terminationStatus == 0 else {
+            throw PreflightError.containerSystemStartFailed
+        }
+
+        // Give the system a moment to become ready
+        Thread.sleep(forTimeInterval: 2)
+
+        guard isContainerSystemRunning() else {
+            throw PreflightError.containerSystemStartFailed
+        }
+
+        print("[roadrunner] Container system started.")
+    }
+
+    private static func isContainerSystemRunning() -> Bool {
         let process = Process()
         process.executableURL = URL(filePath: ContainerRunner.containerCLI)
         process.arguments = ["system", "status"]
@@ -23,20 +55,47 @@ enum Preflight {
         do {
             try process.run()
             process.waitUntilExit()
-            if process.terminationStatus != 0 {
-                throw PreflightError.containerSystemNotRunning
-            }
-        } catch is PreflightError {
-            throw PreflightError.containerSystemNotRunning
+            return process.terminationStatus == 0
         } catch {
-            throw PreflightError.containerSystemNotRunning
+            return false
         }
+    }
+
+    /// Path to the default kernel symlink created by `container system kernel set`
+    static let kernelSymlink = FileManager.default.homeDirectoryForCurrentUser
+        .appending(path: "Library/Application Support/com.apple.container/kernels/default.kernel-arm64")
+
+    private static func ensureKernelConfigured() throws {
+        let kernelLink = kernelSymlink
+
+        if FileManager.default.fileExists(atPath: kernelLink.path) { return }
+
+        print("[roadrunner] No Linux kernel configured, installing recommended kernel...")
+        let process = Process()
+        process.executableURL = URL(filePath: ContainerRunner.containerCLI)
+        process.arguments = ["system", "kernel", "set", "--recommended"]
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            throw PreflightError.kernelInstallFailed
+        }
+
+        guard process.terminationStatus == 0 else {
+            throw PreflightError.kernelInstallFailed
+        }
+
+        print("[roadrunner] Kernel installed.")
     }
 }
 
 enum PreflightError: Error, CustomStringConvertible {
     case containerCLINotFound
-    case containerSystemNotRunning
+    case containerSystemStartFailed
+    case kernelInstallFailed
 
     var description: String {
         switch self {
@@ -51,15 +110,19 @@ enum PreflightError: Error, CustomStringConvertible {
             Or download from:
                 https://github.com/apple/container/releases
             """
-        case .containerSystemNotRunning:
+        case .containerSystemStartFailed:
             """
-            Container system is not running.
+            Failed to start container system.
 
-            Start it with:
-                brew services start container
-
-            Or manually:
+            Try starting it manually:
                 container system start
+            """
+        case .kernelInstallFailed:
+            """
+            Failed to install Linux kernel.
+
+            Try installing it manually:
+                container system kernel set --recommended
             """
         }
     }

--- a/Tests/RoadrunnerTests/PreflightTests.swift
+++ b/Tests/RoadrunnerTests/PreflightTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import roadrunner
+
+@Suite("Preflight Errors")
+struct PreflightErrorTests {
+    @Test("containerCLINotFound mentions brew install")
+    func cliNotFoundMessage() {
+        let error = PreflightError.containerCLINotFound
+        #expect(error.description.contains("brew install container"))
+    }
+
+    @Test("containerCLINotFound mentions GitHub releases")
+    func cliNotFoundGitHub() {
+        let error = PreflightError.containerCLINotFound
+        #expect(error.description.contains("github.com/apple/container"))
+    }
+
+    @Test("containerSystemStartFailed mentions manual start command")
+    func systemStartFailedMessage() {
+        let error = PreflightError.containerSystemStartFailed
+        #expect(error.description.contains("container system start"))
+    }
+
+    @Test("kernelInstallFailed mentions recommended flag")
+    func kernelInstallFailedMessage() {
+        let error = PreflightError.kernelInstallFailed
+        #expect(error.description.contains("container system kernel set --recommended"))
+    }
+}
+
+@Suite("Preflight Kernel Path")
+struct PreflightKernelPathTests {
+    @Test("Kernel symlink path is in Application Support")
+    func kernelPathLocation() {
+        let path = Preflight.kernelSymlink.path
+        #expect(path.contains("Library/Application Support/com.apple.container"))
+    }
+
+    @Test("Kernel symlink is for arm64 architecture")
+    func kernelPathArm64() {
+        let path = Preflight.kernelSymlink.path
+        #expect(path.hasSuffix("default.kernel-arm64"))
+    }
+
+    @Test("Kernel symlink is in kernels directory")
+    func kernelPathDirectory() {
+        let path = Preflight.kernelSymlink.path
+        #expect(path.contains("/kernels/"))
+    }
+}


### PR DESCRIPTION
## Summary
- Preflight now auto-starts the container system if it's not running
- Preflight now auto-installs the recommended kernel if none is configured for arm64
- Falls back to clear error messages with manual commands if auto-fix fails
- Fixes a bug where `.path()` percent-encoded spaces in the kernel symlink path

Fixes #7

## Test plan
- [x] 7 new tests for preflight error messages and kernel path construction
- [x] All 60 tests pass
- [ ] Verify on a machine with no kernel configured that `roadrunner run` auto-installs it
- [ ] Verify on a machine with container system stopped that `roadrunner run` auto-starts it

🤖 Generated with [Claude Code](https://claude.com/claude-code)